### PR TITLE
Increase test coverage

### DIFF
--- a/src/Router/RouteMatch.php
+++ b/src/Router/RouteMatch.php
@@ -41,9 +41,10 @@ class RouteMatch extends BaseRouteMatch
     {
         if ($this->matchedRouteName === null) {
             $this->matchedRouteName = $name;
-        } else {
-            $this->matchedRouteName = $name . '/' . $this->matchedRouteName;
+            return $this;
         }
+
+        $this->matchedRouteName = $name . '/' . $this->matchedRouteName;
 
         return $this;
     }

--- a/test/ResponseSender/ConsoleResponseSenderTest.php
+++ b/test/ResponseSender/ConsoleResponseSenderTest.php
@@ -78,4 +78,13 @@ class ConsoleResponseSenderTest extends TestCase
         $mockSendResponseEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
         return $mockSendResponseEvent;
     }
+
+    public function testInvocationReturnsEarlyIfResponseIsNotAConsoleResponse()
+    {
+        $event = $this->prophesize(SendResponseEvent::class);
+        $event->getResponse()->willReturn(null)->shouldBeCalledTimes(1);
+
+        $sender = new ConsoleResponseSender();
+        $this->assertNull($sender($event->reveal()));
+    }
 }

--- a/test/Router/CatchallTest.php
+++ b/test/Router/CatchallTest.php
@@ -8,7 +8,10 @@
 namespace ZendTest\Mvc\Console\Router;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Console\Request;
 use Zend\Mvc\Console\Router\Catchall;
+use Zend\Mvc\Console\Router\RouteMatch;
+use Zend\Stdlib\RequestInterface;
 
 class CatchallTest extends TestCase
 {
@@ -26,5 +29,29 @@ class CatchallTest extends TestCase
     public function testFactoryReturnsInstanceForAnyOptionsArray($options)
     {
         $this->assertInstanceOf(Catchall::class, Catchall::factory($options));
+    }
+
+    public function testMatchReturnsEarlyForNonConsoleRequests()
+    {
+        $request = $this->prophesize(RequestInterface::class)->reveal();
+        $route = new Catchall();
+        $this->assertNull($route->match($request));
+    }
+
+    public function testMatchReturnsConstructorParamsForConsoleRequests()
+    {
+        $params = ['foo' => 'bar'];
+        $request = $this->prophesize(Request::class)->reveal();
+        $route = new Catchall($params);
+        $result = $route->match($request);
+        $this->assertInstanceOf(RouteMatch::class, $result);
+        $this->assertEquals($params, $result->getParams());
+    }
+
+    public function testAssembleClearsAssembledParams()
+    {
+        $route = new Catchall();
+        $route->assemble();
+        $this->assertEquals([], $route->getAssembledParams());
     }
 }

--- a/test/Router/ConsoleRouterDelegatorFactoryTest.php
+++ b/test/Router/ConsoleRouterDelegatorFactoryTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Router;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Console\Router\ConsoleRouterDelegatorFactory;
+use ZendTest\Mvc\Console\Service\FactoryEnvironmentTrait;
+
+class ConsoleRouterDelegatorFactoryTest extends TestCase
+{
+    use FactoryEnvironmentTrait;
+
+    public function environments()
+    {
+        return [
+            'console' => [true],
+            'http'    => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider environments
+     */
+    public function testReturnsOriginalServiceWhenRequestedServiceIsNotConsoleRouterOrRouter($consoleFlag)
+    {
+        $this->setConsoleEnvironment($consoleFlag);
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ConsoleRouter')->shouldNotBeCalled();
+        $factory   = new ConsoleRouterDelegatorFactory();
+
+        $this->assertEquals('FOO', $factory(
+            $container->reveal(),
+            'not-a-router',
+            function () {
+                return 'FOO';
+            }
+        ));
+    }
+
+    /**
+     * @dataProvider environments
+     */
+    public function testReturnsConsoleRouterServiceIfRequestedNameIsConsoleRouter($consoleFlag)
+    {
+        $this->setConsoleEnvironment($consoleFlag);
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ConsoleRouter')->willReturn('ConsoleRouter');
+
+        $factory   = new ConsoleRouterDelegatorFactory();
+
+        $this->assertEquals('ConsoleRouter', $factory(
+            $container->reveal(),
+            'ConsoleRouter',
+            function () {
+                return 'FOO';
+            }
+        ));
+    }
+
+    public function routerServiceNames()
+    {
+        return [
+            ['router'],
+            ['Router'],
+            ['ROUTER'],
+        ];
+    }
+
+    /**
+     * @dataProvider routerServiceNames
+     */
+    public function testReturnsConsoleRouterServiceIfRequestedNameIsRouterAndInConsoleEnvironment($routerServiceName)
+    {
+        $this->setConsoleEnvironment(true);
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ConsoleRouter')->willReturn('ConsoleRouter');
+
+        $factory   = new ConsoleRouterDelegatorFactory();
+
+        $this->assertEquals('ConsoleRouter', $factory(
+            $container->reveal(),
+            $routerServiceName,
+            function () {
+                return 'FOO';
+            }
+        ));
+    }
+
+    /**
+     * @dataProvider routerServiceNames
+     */
+    public function testReturnsOriginalServiceIfRequestedNameIsRouterAndNotInConsoleEnvironment($routerServiceName)
+    {
+        $this->setConsoleEnvironment(false);
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ConsoleRouter')->shouldNotBeCalled();
+
+        $factory   = new ConsoleRouterDelegatorFactory();
+
+        $this->assertEquals('FOO', $factory(
+            $container->reveal(),
+            $routerServiceName,
+            function () {
+                return 'FOO';
+            }
+        ));
+    }
+}

--- a/test/Router/ConsoleRouterFactoryTest.php
+++ b/test/Router/ConsoleRouterFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Router;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Console\Router\ConsoleRouterFactory;
+use Zend\Mvc\Console\Router\SimpleRouteStack;
+use Zend\Router\RoutePluginManager;
+
+class ConsoleRouterFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new ConsoleRouterFactory();
+    }
+
+    public function testReturnsASimpleRouteStackByDefaultWithNoConfig()
+    {
+        $container = $this->container;
+        $container->has('config')->willReturn(false);
+        $container->get('RoutePluginManager')->will(function () use ($container) {
+            return new RoutePluginManager($container->reveal());
+        });
+        $router = $this->factory->__invoke($container->reveal(), 'ConsoleRouter');
+        $this->assertInstanceOf(SimpleRouteStack::class, $router);
+        $this->assertCount(0, $router->getRoutes());
+    }
+
+    public function testWillUseEmptyConfigToCreateSimpleRouteStackIfPresent()
+    {
+        $container = $this->container;
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([]);
+        $container->get('RoutePluginManager')->will(function () use ($container) {
+            return new RoutePluginManager($container->reveal());
+        });
+        $router = $this->factory->__invoke($container->reveal(), 'ConsoleRouter');
+        $this->assertInstanceOf(SimpleRouteStack::class, $router);
+        $this->assertCount(0, $router->getRoutes());
+    }
+
+    public function testWillUseEmptyRouterConfigToCreateSimpleRouteStackIfPresent()
+    {
+        $container = $this->container;
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['console' => ['router' => []]]);
+        $container->get('RoutePluginManager')->will(function () use ($container) {
+            return new RoutePluginManager($container->reveal());
+        });
+        $router = $this->factory->__invoke($container->reveal(), 'ConsoleRouter');
+        $this->assertInstanceOf(SimpleRouteStack::class, $router);
+        $this->assertCount(0, $router->getRoutes());
+    }
+
+    public function testWillUseRouterConfigToCreateSimpleRouteStack()
+    {
+        $container = $this->container;
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['console' => ['router' => ['routes' => [
+            'test' => [
+                'options' => [
+                    'route' => 'test',
+                ],
+            ],
+        ]]]]);
+        $container->get('RoutePluginManager')->will(function () use ($container) {
+            return new RoutePluginManager($container->reveal());
+        });
+        $router = $this->factory->__invoke($container->reveal(), 'ConsoleRouter');
+        $this->assertInstanceOf(SimpleRouteStack::class, $router);
+        $this->assertCount(1, $router->getRoutes());
+    }
+}

--- a/test/Router/RouteMatchTest.php
+++ b/test/Router/RouteMatchTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Router;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Console\Router\RouteMatch;
+
+class RouteMatchTest extends TestCase
+{
+    public function testConstructorCanAcceptArgumentLength()
+    {
+        $routeMatch = new RouteMatch(['foo' => true], 5);
+        $this->assertEquals(5, $routeMatch->getLength());
+    }
+
+    public function testSettingMatchedRouteNameForFirstTimeSetsItVerbatim()
+    {
+        $routeMatch = new RouteMatch(['foo' => true], 5);
+        $routeMatch->setMatchedRouteName('foo');
+        $this->assertEquals('foo', $routeMatch->getMatchedRouteName());
+        return $routeMatch;
+    }
+
+    /**
+     * @depends testSettingMatchedRouteNameForFirstTimeSetsItVerbatim
+     */
+    public function testSettingMatchedRouteNameSubsequentTimePrependsNewName($routeMatch)
+    {
+        $routeMatch->setMatchedRouteName('bar');
+        $this->assertEquals('bar/foo', $routeMatch->getMatchedRouteName());
+    }
+
+    public function testAllowsMergingWithAnotherInstance()
+    {
+        $first = new RouteMatch(['foo' => true], 5);
+        $second = new RouteMatch(['bar' => 'baz'], 9);
+
+        $merged = $first->merge($second);
+        $this->assertSame($first, $merged);
+        $this->assertEquals(14, $merged->getLength());
+        $this->assertEquals($second->getMatchedRouteName(), $merged->getMatchedRouteName());
+        $this->assertEquals([
+            'foo' => true,
+            'bar' => 'baz',
+        ], $merged->getParams());
+    }
+}

--- a/test/View/InjectNamedConsoleParamsListenerTest.php
+++ b/test/View/InjectNamedConsoleParamsListenerTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\View;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Console\Request;
+use Zend\EventManager\EventManager;
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
+use Zend\Mvc\Console\Router\RouteMatch;
+use Zend\Mvc\Console\View\InjectNamedConsoleParamsListener;
+use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\Parameters;
+
+class InjectNamedConsoleParamsListenerTest extends TestCase
+{
+    use EventListenerIntrospectionTrait;
+
+    public function setUp()
+    {
+        $this->listener = new InjectNamedConsoleParamsListener();
+    }
+
+    public function testAttachesToEventManagerAtExpectedPriority()
+    {
+        $events = new EventManager();
+        $this->listener->attach($events);
+
+        $this->assertListenerAtPriority(
+            [$this->listener, 'injectNamedParams'],
+            -80,
+            MvcEvent::EVENT_DISPATCH,
+            $events,
+            'Listener not attached at expected priority'
+        );
+    }
+
+    public function testReturnsEarlyIfNoRouteMatchPresentInEvent()
+    {
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getRouteMatch()->willReturn(null);
+        $event->getRequest()->shouldNotBeCalled();
+
+        $this->assertNull($this->listener->injectNamedParams($event->reveal()));
+    }
+
+    public function testReturnsEarlyIfRequestIsNotFromConsoleEnvironment()
+    {
+        $routeMatch = $this->prophesize(RouteMatch::class);
+        $routeMatch->getParams()->shouldNotBeCalled();
+
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getRouteMatch()->willReturn($routeMatch->reveal());
+        $event->getRequest()->willReturn(null);
+
+        $this->assertNull($this->listener->injectNamedParams($event->reveal()));
+    }
+
+    public function testInjectsRequestWithRouteMatchParams()
+    {
+        $requestParams = $this->prophesize(Parameters::class);
+        $requestParams->toArray()->willReturn([
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ]);
+        $requestParams->fromArray([
+            'foo' => 'bar',
+            'bar' => 'BAZ',
+            'baz' => 'bat',
+            'bat' => 'quz',
+        ])->shouldBeCalled();
+
+        $routeMatch = $this->prophesize(RouteMatch::class);
+        $routeMatch->getParams()->willReturn([
+            'bar' => 'BAZ',
+            'bat' => 'quz',
+        ]);
+
+        $request = $this->prophesize(Request::class);
+        $request->getParams()->willReturn($requestParams->reveal())->shouldBeCalledTimes(2);
+
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getRouteMatch()->willReturn($routeMatch->reveal());
+        $event->getRequest()->willReturn($request->reveal());
+
+        $this->assertNull($this->listener->injectNamedParams($event->reveal()));
+    }
+}

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -6,12 +6,29 @@
  */
 namespace ZendTest\Mvc\Console\View;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
 use ReflectionClass;
+use Zend\Console\Adapter\AdapterInterface;
+use Zend\Console\ColorInterface;
+use Zend\Console\Request;
+use Zend\Console\Response;
+use Zend\EventManager\EventManager;
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
+use Zend\ModuleManager\Feature\ConsoleBannerProviderInterface;
+use Zend\ModuleManager\Feature\ConsoleUsageProviderInterface;
+use Zend\ModuleManager\ModuleManager;
+use Zend\Mvc\Application;
+use Zend\Mvc\Console\Exception\RuntimeException;
 use Zend\Mvc\Console\View\RouteNotFoundStrategy;
+use Zend\Mvc\Console\View\ViewModel;
+use Zend\Mvc\MvcEvent;
 
 class RouteNotFoundStrategyTest extends TestCase
 {
+    use EventListenerIntrospectionTrait;
+
     /**
      * @var RouteNotFoundStrategy
      */
@@ -22,6 +39,49 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy = new RouteNotFoundStrategy();
     }
 
+    public function mockLoadedModules()
+    {
+        $first = $this->prophesize(ConsoleBannerProviderInterface::class);
+        $first->willImplement(ConsoleUsageProviderInterface::class);
+        $first->getConsoleBanner(Argument::type(AdapterInterface::class))->willReturn('');
+        $first->getConsoleUsage(Argument::type(AdapterInterface::class))->willReturn(['FIRST USAGE']);
+
+        $second = $this->prophesize(ConsoleBannerProviderInterface::class);
+        $second->getConsoleBanner(Argument::type(AdapterInterface::class))->willReturn('SECOND BANNER');
+
+        $third = $this->prophesize(TestAsset\ConsoleModule::class);
+        $third->getConsoleBanner(Argument::type(AdapterInterface::class))->willReturn('THIRD BANNER');
+        $third->getConsoleUsage(Argument::type(AdapterInterface::class))->willReturn('THIRD USAGE');
+
+        $fourth = $this->prophesize(TestAsset\ConsoleModule::class);
+        $fourth->getConsoleBanner(Argument::type(AdapterInterface::class))->willReturn('');
+        $fourth->getConsoleUsage(Argument::type(AdapterInterface::class))->willReturn([
+            '--foo' => 'BAR',
+            ['--bar', 'Just another flag'],
+        ]);
+
+        return [
+            'First'  => $first->reveal(),
+            'Second' => $second->reveal(),
+            'Third'  => $third->reveal(),
+            'Fourth' => $fourth->reveal(),
+        ];
+    }
+
+    public function testAttachesToEventManagerAtExpectedPriority()
+    {
+        $events = new EventManager();
+        $this->strategy->attach($events);
+
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'handleRouteNotFoundError'],
+            1,
+            MvcEvent::EVENT_DISPATCH_ERROR,
+            $events,
+            'Route not found listener not attached at expected priority'
+        );
+    }
+
     public function testRenderTableConcatenateAndInvalidInputDoesNotThrowException()
     {
         $reflection = new ReflectionClass(RouteNotFoundStrategy::class);
@@ -29,5 +89,144 @@ class RouteNotFoundStrategyTest extends TestCase
         $method->setAccessible(true);
         $result = $method->invokeArgs($this->strategy, [[[]], 1, 0]);
         $this->assertSame('', $result);
+    }
+
+    public function testListenerDoesNothingIfEventHasNoError()
+    {
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getError()->willReturn(null);
+        $event->getResponse()->shouldNotBeCalled();
+        $event->getRequest()->shouldNotBeCalled();
+
+        $this->assertNull($this->strategy->handleRouteNotFoundError($event->reveal()));
+    }
+
+    public function testReturnsEarlyForErrorsItDoesNotHandle()
+    {
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getError()->willReturn('unknown-error-type');
+        $event->getResponse()->willReturn(null);
+        $event->getRequest()->willReturn(null);
+        $event->getResult()->shouldNotBeCalled();
+
+        $this->assertNull($this->strategy->handleRouteNotFoundError($event->reveal()));
+    }
+
+    public function validErrorTypes()
+    {
+        return [
+            'controller-not-found' => [Application::ERROR_CONTROLLER_NOT_FOUND, 'Could not match to a controller'],
+            'controller-invalid'   => [Application::ERROR_CONTROLLER_INVALID, 'Invalid controller specified'],
+            'router-no-match'      => [Application::ERROR_ROUTER_NO_MATCH, 'Invalid arguments or no arguments provided'],
+        ];
+    }
+
+    /**
+     * @dataProvider validErrorTypes
+     */
+    public function testSetsResponseErrorMetadataAndReasonToError($type)
+    {
+        $response = $this->prophesize(Response::class);
+        $response->setMetadata('error', $type)->shouldBeCalled();
+
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getError()->willReturn($type);
+        $event->getResponse()->willReturn($response->reveal());
+        $event->getRequest()->willReturn(null);
+        $event->getResult()->willReturn($response->reveal());
+
+        $this->assertNull($this->strategy->handleRouteNotFoundError($event->reveal()));
+        $this->assertAttributeEquals($type, 'reason', $this->strategy);
+    }
+
+    /**
+     * @dataProvider validErrorTypes
+     */
+    public function testLackOfConsoleAdapterRaisesException($type)
+    {
+        $response = $this->prophesize(Response::class);
+        $response->setMetadata('error', $type)->shouldBeCalled();
+
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getError()->willReturn($type);
+        $event->getResponse()->willReturn($response->reveal());
+        $event->getRequest()->willReturn(null);
+        $event->getResult()->willReturn(null);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ModuleManager')->willReturn(null);
+        $container->get('console')->willReturn(null);
+
+        $app = $this->prophesize(Application::class);
+        $app->getServiceManager()->willReturn($container->reveal());
+        $event->getApplication()->willReturn($app->reveal());
+
+        $this->setExpectedException(RuntimeException::class, 'Console adapter');
+        $this->strategy->handleRouteNotFoundError($event->reveal());
+    }
+
+    /**
+     * @dataProvider validErrorTypes
+     */
+    public function testSetsResultToPopulatedViewModelWhenSuccessful($type, $reasonMessage)
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getScriptName()->willReturn('zend-mvc-console-test');
+
+        $response = $this->prophesize(Response::class);
+        $response->setMetadata('error', $type)->shouldBeCalled();
+
+        $event = $this->prophesize(MvcEvent::class);
+        $event->getError()->willReturn($type);
+        $event->getResponse()->willReturn($response->reveal());
+        $event->getRequest()->willReturn($request->reveal());
+        $event->getResult()->willReturn(null);
+        $event->getParam('exception', false)->willReturn(false);
+
+        $moduleManager = $this->prophesize(ModuleManager::class);
+        $moduleManager->getLoadedModules(false)->willReturn($this->mockLoadedModules())->shouldBeCalledTimes(2);
+
+        $console = $this->prophesize(AdapterInterface::class);
+        $console->colorize('SECOND BANNER', ColorInterface::BLUE)->willReturn('SECOND BANNER');
+        $console->colorize('THIRD BANNER', ColorInterface::BLUE)->willReturn('THIRD BANNER');
+        $console->getWidth()->willReturn(80);
+        $console->colorize(Argument::containingString('First'), ColorInterface::RED)->willReturn('First');
+        $console->colorize(Argument::containingString('Third'), ColorInterface::RED)->willReturn('Third');
+        $console->colorize(Argument::containingString('Fourth'), ColorInterface::RED)->willReturn('Fourth');
+        $console->colorize('zend-mvc-console-test --foo', ColorInterface::GREEN)->willReturn('zend-mvc-console-test --foo');
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('ModuleManager')->willReturn($moduleManager->reveal());
+        $container->get('console')->willReturn($console->reveal());
+
+        $app = $this->prophesize(Application::class);
+        $app->getServiceManager()->willReturn($container->reveal());
+        $event->getApplication()->willReturn($app->reveal());
+        $event->setResult(Argument::that(function ($argument) use ($reasonMessage) {
+            if (! $argument instanceof ViewModel) {
+                return false;
+            }
+
+            $result = $argument->getResult();
+            if (! strstr($result, $reasonMessage)) {
+                return false;
+            }
+
+            if (! strstr($result, 'BAR')) {
+                return false;
+            }
+
+            if (! strstr($result, '--bar')) {
+                return false;
+            }
+
+            if (! strstr($result, 'Just another flag')) {
+                return false;
+            }
+
+            return true;
+        }))->shouldBeCalled();
+
+        $this->assertNull($this->strategy->handleRouteNotFoundError($event->reveal()));
     }
 }

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -114,11 +114,13 @@ class RouteNotFoundStrategyTest extends TestCase
 
     public function validErrorTypes()
     {
+        // @codingStandardsIgnoreStart
         return [
             'controller-not-found' => [Application::ERROR_CONTROLLER_NOT_FOUND, 'Could not match to a controller'],
             'controller-invalid'   => [Application::ERROR_CONTROLLER_INVALID, 'Invalid controller specified'],
             'router-no-match'      => [Application::ERROR_ROUTER_NO_MATCH, 'Invalid arguments or no arguments provided'],
         ];
+        // @codingStandardsIgnoreEnd
     }
 
     /**
@@ -193,7 +195,9 @@ class RouteNotFoundStrategyTest extends TestCase
         $console->colorize(Argument::containingString('First'), ColorInterface::RED)->willReturn('First');
         $console->colorize(Argument::containingString('Third'), ColorInterface::RED)->willReturn('Third');
         $console->colorize(Argument::containingString('Fourth'), ColorInterface::RED)->willReturn('Fourth');
-        $console->colorize('zend-mvc-console-test --foo', ColorInterface::GREEN)->willReturn('zend-mvc-console-test --foo');
+        $console
+            ->colorize('zend-mvc-console-test --foo', ColorInterface::GREEN)
+            ->willReturn('zend-mvc-console-test --foo');
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('ModuleManager')->willReturn($moduleManager->reveal());

--- a/test/View/TestAsset/ConsoleModule.php
+++ b/test/View/TestAsset/ConsoleModule.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\View\TestAsset;
+
+class ConsoleModule
+{
+    public function getConsoleBanner()
+    {
+    }
+
+    public function getConsoleUsage()
+    {
+        
+    }
+}

--- a/test/View/TestAsset/ConsoleModule.php
+++ b/test/View/TestAsset/ConsoleModule.php
@@ -15,6 +15,6 @@ class ConsoleModule
 
     public function getConsoleUsage()
     {
-        
+
     }
 }


### PR DESCRIPTION
This patch adds additional coverage and/or new tests for the following classes:
- `RouteNotFoundStrategy`
- `ExceptionStrategy`
- `ConsoleResponseSender`
- `ConsoleRouterFactory`
- `ConsoleRouterDelegatorFactory`
- `RouteMatch`
- `Router\Simple`
- `Router\Catchall`
