### PR TITLE
Import console-specific controller plugins from zend-mvc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "zendframework/zend-view": "^2.6.3"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.3",
+        "squizlabs/php_codesniffer": "^2.3.1",
         "phpunit/PHPUnit": "^4.5",
         "zendframework/zend-filter": "^2.6.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0c81889648bad3304c7abffb27bfd8a6",
-    "content-hash": "9992f3d9af0cf4646c9d20da4aff8299",
+    "hash": "e534104245ac99f8750c5de45d0c92c0",
+    "content-hash": "badac3ab64d35b86406b3b4b35467012",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,7 @@ class ConfigProvider
             ],
             'delegator_factories' => [
                 'Application'               => [ Service\ConsoleApplicationDelegatorFactory::class ],
+                'ControllerManager'         => [ Service\ControllerManagerDelegatorFactory::class ],
                 'ControllerPluginManager'   => [ Service\ControllerPluginManagerDelegatorFactory::class ],
                 'Request'                   => [ Service\ConsoleRequestDelegatorFactory::class ],
                 'Response'                  => [ Service\ConsoleResponseDelegatorFactory::class ],

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,7 @@ class ConfigProvider
             ],
             'delegator_factories' => [
                 'Application'               => [ Service\ConsoleApplicationDelegatorFactory::class ],
+                'ControllerPluginManager'   => [ Service\ControllerPluginManagerDelegatorFactory::class ],
                 'Request'                   => [ Service\ConsoleRequestDelegatorFactory::class ],
                 'Response'                  => [ Service\ConsoleResponseDelegatorFactory::class ],
                 'Router'                    => [ Router\ConsoleRouterDelegatorFactory::class ],

--- a/src/Controller/AbstractConsoleController.php
+++ b/src/Controller/AbstractConsoleController.php
@@ -10,10 +10,14 @@ namespace Zend\Mvc\Console\Controller;
 use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Mvc\Console\Exception\InvalidArgumentException;
+use Zend\Mvc\Console\View\ViewModel;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
 
+/**
+  * @method \Zend\Mvc\Console\View\ViewModel createConsoleNotFoundModel()
+ */
 class AbstractConsoleController extends AbstractActionController
 {
     /**
@@ -50,5 +54,20 @@ class AbstractConsoleController extends AbstractActionController
             ));
         }
         return parent::dispatch($request, $response);
+    }
+
+    /**
+     * Action called if matched action does not exist.
+     *
+     * @return ViewModel
+     */
+    public function notFoundAction()
+    {
+        $event = $this->getEvent();
+        $routeMatch = $event->getRouteMatch();
+        $routeMatch->setParam('action', 'not-found');
+
+        $helper = $this->plugin('createConsoleNotFoundModel');
+        return $helper();
     }
 }

--- a/src/Controller/AbstractConsoleController.php
+++ b/src/Controller/AbstractConsoleController.php
@@ -18,7 +18,7 @@ use Zend\Stdlib\ResponseInterface;
 /**
   * @method \Zend\Mvc\Console\View\ViewModel createConsoleNotFoundModel()
  */
-class AbstractConsoleController extends AbstractActionController
+abstract class AbstractConsoleController extends AbstractActionController
 {
     /**
      * @var ConsoleAdapter

--- a/src/Controller/Plugin/CreateConsoleNotFoundModel.php
+++ b/src/Controller/Plugin/CreateConsoleNotFoundModel.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Console\Controller\Plugin;
+
+use Zend\Mvc\Console\View\ViewModel as ConsoleModel;
+use Zend\Mvc\Controller\Plugin\AbstractPlugin;
+
+class CreateConsoleNotFoundModel extends AbstractPlugin
+{
+    /**
+     * Create a console view model representing a "not found" action
+     *
+     * @return ConsoleModel
+     */
+    public function __invoke()
+    {
+        $viewModel = new ConsoleModel();
+
+        $viewModel->setErrorLevel(1);
+        $viewModel->setResult('Page not found');
+
+        return $viewModel;
+    }
+}

--- a/src/Service/ControllerManagerDelegatorFactory.php
+++ b/src/Service/ControllerManagerDelegatorFactory.php
@@ -56,20 +56,17 @@ class ControllerManagerDelegatorFactory implements DelegatorFactoryInterface
     public function injectConsole($first, $second)
     {
         if ($first instanceof ContainerInterface) {
+            // v3
             $container = $first;
             $controller = $second;
         } else {
-            $container = $second;
+            // For v2, we need to pull the parent service locator
+            $container = $second->getServiceLocator() ?: $second;
             $controller = $first;
         }
 
         if (! $controller instanceof AbstractConsoleController) {
             return;
-        }
-
-        // For v2, we need to pull the parent service locator
-        if (! method_exists($container, 'configure')) {
-            $container = $container->getServiceLocator() ?: $container;
         }
 
         $controller->setConsole($container->get('Console'));

--- a/src/Service/ControllerManagerDelegatorFactory.php
+++ b/src/Service/ControllerManagerDelegatorFactory.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Console\Service;
+
+use Interop\Container\ContainerInterface;
+use Zend\Mvc\Console\Controller\AbstractConsoleController;
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ControllerManagerDelegatorFactory implements DelegatorFactoryInterface
+{
+    /**
+     * Add a ControllerManager initializer to inject the console into AbstractConsoleController instances.
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param callable $callback
+     * @param null|array $options
+     * @return \Zend\Mvc\Controller\ControllerManager
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    {
+        $controllers = $callback();
+        $controllers->addInitializer([$this, 'injectConsole']);
+        return $controllers;
+    }
+
+    /**
+     * Add a ControllerManager initializer to inject the console into AbstractConsoleController instances. (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name
+     * @param string $requestedName
+     * @param callable $callback
+     * @return \Zend\Mvc\Controller\ControllerManager
+     */
+    public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)
+    {
+        return $this($container, $requestedName, $callback);
+    }
+
+    /**
+     * Initializer: inject a Console instance into AbstractConsoleController instances.
+     *
+     * @param ContainerInterface|mixed $first ContainerInterface under
+     *     zend-servicemanager v3, instance to inspect under v2.
+     * @param mixed|ServiceLocatorInterface $second Instance to inspect
+     *     under zend-servicemanager v3, plugin manager under v3.
+     * @return void
+     */
+    public function injectConsole($first, $second)
+    {
+        if ($first instanceof ContainerInterface) {
+            $container = $first;
+            $controller = $second;
+        } else {
+            $container = $second;
+            $controller = $first;
+        }
+
+        if (! $controller instanceof AbstractConsoleController) {
+            return;
+        }
+
+        // For v2, we need to pull the parent service locator
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        $controller->setConsole($container->get('Console'));
+    }
+}

--- a/src/Service/ControllerPluginManagerDelegatorFactory.php
+++ b/src/Service/ControllerPluginManagerDelegatorFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Console\Service;
+
+use Interop\Container\ContainerInterface;
+use Zend\Mvc\Console\Controller\Plugin\CreateConsoleNotFoundModel;
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ControllerPluginManagerDelegatorFactory implements DelegatorFactoryInterface
+{
+    /**
+     * Add console-specific plugins to the controller PluginManager.
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param callable $callback
+     * @param null|array $options
+     * @return \Zend\Mvc\Controller\PluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback, array $options = null)
+    {
+        $plugins = $callback();
+
+        $plugins->setAlias('CreateConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
+        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
+        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
+        $plugins->setFactory(CreateConsoleNotFoundModel::class, InvokableFactory::class);
+
+        return $plugins;
+    }
+
+    /**
+     * Add console-specific plugins to the controller PluginManager. (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name
+     * @param string $requestedName
+     * @param callable $callback
+     * @return \Zend\Mvc\Controller\PluginManager
+     */
+    public function createDelegatorWithName(ServiceLocatorInterface $container, $name, $requestedName, $callback)
+    {
+        return $this($container, $requestedName, $callback);
+    }
+}

--- a/src/Service/ControllerPluginManagerDelegatorFactory.php
+++ b/src/Service/ControllerPluginManagerDelegatorFactory.php
@@ -30,7 +30,7 @@ class ControllerPluginManagerDelegatorFactory implements DelegatorFactoryInterfa
 
         $plugins->setAlias('CreateConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
         $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
-        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class);
+        $plugins->setAlias('createconsolenotfoundmodel', CreateConsoleNotFoundModel::class);
         $plugins->setFactory(CreateConsoleNotFoundModel::class, InvokableFactory::class);
 
         return $plugins;

--- a/test/Controller/Plugin/CreateConsoleNotFoundModelTest.php
+++ b/test/Controller/Plugin/CreateConsoleNotFoundModelTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Controller\Plugin;
+
+use PHPUnit_framework_TestCase as TestCase;
+use Zend\Mvc\Console\Controller\Plugin\CreateConsoleNotFoundModel;
+use Zend\Mvc\Console\View\ViewModel as ConsoleModel;
+
+class CreateConsoleNotFoundModelTest extends TestCase
+{
+    public function testCanReturnModelWithErrorMessageAndErrorLevel()
+    {
+        $plugin = new CreateConsoleNotFoundModel();
+        $model  = $plugin();
+
+        $this->assertInstanceOf(ConsoleModel::class, $model);
+        $this->assertSame('Page not found', $model->getResult());
+        $this->assertSame(1, $model->getErrorLevel());
+    }
+}

--- a/test/Service/ControllerManagerDelegatorFactoryTest.php
+++ b/test/Service/ControllerManagerDelegatorFactoryTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Service;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Zend\Console\Adapter\AdapterInterface;
+use Zend\Mvc\Console\Controller\AbstractConsoleController;
+use Zend\Mvc\Console\Service\ControllerManagerDelegatorFactory;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\ServiceManager\ServiceManager;
+
+class ControllerManagerDelegatorFactoryTest extends TestCase
+{
+    public function testInjectsConsoleInitializerIntoControllerManager()
+    {
+        $controllers = $this->prophesize(ControllerManager::class);
+        $controllers->addInitializer(Argument::that(function ($argument) {
+            if (! is_callable($argument)) {
+                return false;
+            }
+
+            if (! is_array($argument) || 2 !== count($argument)) {
+                return false;
+            }
+
+            $object = array_shift($argument);
+            if (! $object instanceof ControllerManagerDelegatorFactory) {
+                return false;
+            }
+
+            $method = array_shift($argument);
+            if ($method !== 'injectConsole') {
+                return false;
+            }
+
+            return true;
+        }))->shouldBeCalled();
+
+        $callback = function () use ($controllers) {
+            return $controllers->reveal();
+        };
+
+        $factory = new ControllerManagerDelegatorFactory();
+
+        $this->assertSame($controllers->reveal(), $factory(
+            $this->prophesize(ContainerInterface::class)->reveal(),
+            'ControllerManager',
+            $callback
+        ));
+    }
+
+    public function testInitializerDoesNothingForNonAbstractConsoleControllers()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('Console')->shouldNotBeCalled();
+        $instance = (object) [];
+
+        $factory = new ControllerManagerDelegatorFactory();
+        $this->assertNull($factory->injectConsole($container->reveal(), $instance));
+    }
+
+    public function testInitializerInjectsConsoleIntoAbstractConsoleControllers()
+    {
+        $console = $this->prophesize(AdapterInterface::class)->reveal();
+
+        $controller = $this->prophesize(AbstractConsoleController::class);
+        $controller->setConsole($console)->shouldBeCalled();
+
+        // Using SM instance to allow testing against both v2 and v3
+        $container = new ServiceManager();
+        $container->setService('Console', $console);
+
+        $factory = new ControllerManagerDelegatorFactory();
+        $this->assertNull($factory->injectConsole($container, $controller->reveal()));
+    }
+
+    public function testFlippedArgumentInitializerDoesNothingForNonAbstractConsoleControllers()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('Console')->shouldNotBeCalled();
+        $instance = (object) [];
+
+        $factory = new ControllerManagerDelegatorFactory();
+        $this->assertNull($factory->injectConsole($instance, $container->reveal()));
+    }
+
+    public function testFlippedArgumentInitializerInjectsConsoleIntoAbstractConsoleControllers()
+    {
+        $console = $this->prophesize(AdapterInterface::class)->reveal();
+
+        $controller = $this->prophesize(AbstractConsoleController::class);
+        $controller->setConsole($console)->shouldBeCalled();
+
+        // Using SM instance to allow testing against both v2 and v3
+        $container = new ServiceManager();
+        $container->setService('Console', $console);
+
+        $factory = new ControllerManagerDelegatorFactory();
+        $this->assertNull($factory->injectConsole($controller->reveal(), $container));
+    }
+}

--- a/test/Service/ControllerPluginManagerDelegatorFactoryTest.php
+++ b/test/Service/ControllerPluginManagerDelegatorFactoryTest.php
@@ -21,7 +21,7 @@ class ControllerPluginManagerDelegatorFactoryTest extends TestCase
         $plugins = $this->prophesize(PluginManager::class);
         $plugins->setAlias('CreateConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
         $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
-        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
+        $plugins->setAlias('createconsolenotfoundmodel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
         $plugins->setFactory(CreateConsoleNotFoundModel::class, InvokableFactory::class)->shouldBeCalled();
 
         $callback = function () use ($plugins) {

--- a/test/Service/ControllerPluginManagerDelegatorFactoryTest.php
+++ b/test/Service/ControllerPluginManagerDelegatorFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc-console for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Console\Service;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Console\Controller\Plugin\CreateConsoleNotFoundModel;
+use Zend\Mvc\Console\Service\ControllerPluginManagerDelegatorFactory;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+class ControllerPluginManagerDelegatorFactoryTest extends TestCase
+{
+    public function testReturnsPluginManagerWithConfigurationForCreateConsoleNotFoundModelPlugin()
+    {
+        $plugins = $this->prophesize(PluginManager::class);
+        $plugins->setAlias('CreateConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
+        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
+        $plugins->setAlias('createConsoleNotFoundModel', CreateConsoleNotFoundModel::class)->shouldBeCalled();
+        $plugins->setFactory(CreateConsoleNotFoundModel::class, InvokableFactory::class)->shouldBeCalled();
+
+        $callback = function () use ($plugins) {
+            return $plugins->reveal();
+        };
+
+        $factory = new ControllerPluginManagerDelegatorFactory();
+        $this->assertSame($plugins->reveal(), $factory(
+            $this->prophesize(ContainerInterface::class)->reveal(),
+            'ControllerPluginManager',
+            $callback
+        ));
+    }
+}


### PR DESCRIPTION
This patch brings in the `CreateConsoleNotFoundModel` plugin from zend-mvc, and ensures:
- it's tested.
- a delegator factory will configure it in the controller `PluginManager` instance.

Marked as a WIP, until:
- [x] includes delegator factory for ControllerManager, to add the `injectConsole` initializer.
- [x] overrides the `notFoundAction()` inside `AbstractConsoleController` to invoke the `createConsoleNotFoundModel()` plugin.
- [x] `AbstractConsoleController` is marked abstract.
