### PR TITLE
Allow handling any Throwable

### DIFF
--- a/src/View/ExceptionStrategy.php
+++ b/src/View/ExceptionStrategy.php
@@ -182,7 +182,10 @@ EOT;
                 if (is_callable($this->message)) {
                     $callback = $this->message;
                     $message = (string) $callback($exception, $this->displayExceptions);
-                } elseif ($this->displayExceptions && $exception instanceof \Exception) {
+                } elseif ($this->displayExceptions
+                    // @todo clean up once PHP 7 requirement is enforced
+                    && ($exception instanceof \Exception || $exception instanceof \Throwable)
+                ) {
                     $previous = '';
                     $previousException = $exception->getPrevious();
                     while ($previousException) {

--- a/src/View/RouteNotFoundStrategy.php
+++ b/src/View/RouteNotFoundStrategy.php
@@ -457,7 +457,8 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
         ];
         $report = sprintf("\nReason for failure: %s\n", $reasons[$reason]);
 
-        while ($exception instanceof \Exception) {
+        // @todo clean up once PHP 7 requirement is enforced
+        while ($exception instanceof \Exception || $exception instanceof \Throwable) {
             $report .= sprintf(
                 "Exception: %s\nTrace:\n%s\n",
                 $exception->getMessage(),

--- a/test/View/ExceptionStrategyTest.php
+++ b/test/View/ExceptionStrategyTest.php
@@ -179,7 +179,21 @@ class ExceptionStrategyTest extends TestCase
         }
     }
 
-    public function testPrepareExceptionViewModelErrorException()
+    public function throwables()
+    {
+        $throwables = ['exception' => [\Exception::class]];
+
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $throwables['error'] = [\Error::class];
+        }
+
+        return $throwables;
+    }
+
+    /**
+     * @dataProvider throwables
+     */
+    public function testPrepareExceptionViewModelErrorException($throwable)
     {
         $errors = [Application::ERROR_EXCEPTION, 'user-defined-error'];
 
@@ -187,7 +201,7 @@ class ExceptionStrategyTest extends TestCase
             $events = new EventManager();
             $this->strategy->attach($events);
 
-            $exception = new \Exception('message foo');
+            $exception = new $throwable('message foo');
             $event = new MvcEvent(MvcEvent::EVENT_DISPATCH_ERROR, null, ['exception' => $exception]);
 
             $event->setError($error);


### PR DESCRIPTION
Based on zendframework/zend-mvc#138, this patch adds support for handling any Throwable, not just Exceptions, when reporting exceptions and route not found information; the patch includes tests of both changes in behavior.
