### PR TITLE
Updated dependencies and conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env:
-        - DEPS=lowest
-    - php: 5.5
-      env:
-        - DEPS=locked
-    - php: 5.5
-      env:
-        - DEPS=latest
     - php: 5.6
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "homepage": "https://github.com/zendframework/zend-mvc-console",
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
@@ -29,6 +29,9 @@
     },
     "suggest": {
         "zendframework/zend-filter": "^2.6.1, to filter rendered results"
+    },
+    "conflict": {
+        "zendframework/zend-mvc": "<3.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Removed support for PHP 5.5
- Mark as a conflict with zend-mvc < 3.0.0 (as it defines code in the same namepaces)
