### PR TITLE
added failing test case regarding issue #9

### DIFF
--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+use Interop\Container\ContainerInterface;
+
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
+use Zend\Mvc\SendResponseListener;
+use Zend\Mvc\Service\ServiceManagerConfig;
+
+use Zend\Mvc\Console\ResponseSender\ConsoleResponseSender;
+use Zend\Mvc\Console\Service\ConsoleResponseSenderDelegatorFactory;
+
+class ServiceManagerTest extends TestCase
+{
+		public function testEventManagerOverridden()
+		{
+				$minimalConfig = [
+						'aliases' => [
+								'SendResponseListener' => SendResponseListener::class,
+						],
+						'factories' => [
+								SendResponseListener::class => InvokableFactory::class
+						],
+						'delegators' => [
+								SendResponseListener::class => [
+										function(ContainerInterface $container, $name, callable $callback, array $options = null) {
+												$consoleResponseSenderDelegatorFactory = new ConsoleResponseSenderDelegatorFactory();
+												$sendResponseListener = $consoleResponseSenderDelegatorFactory->__invoke($container, $name, $callback, $options);
+												$this->assertInstanceOf(SendResponseListener::class, $sendResponseListener);
+
+												$eventManager = $sendResponseListener->getEventManager();
+												$this->assertEvents($eventManager);
+
+												return $sendResponseListener;
+										}
+								],
+						]
+				];
+
+				$smConfig = new ServiceManagerConfig($minimalConfig);
+
+				$serviceManager = new ServiceManager();
+				$smConfig->configureServiceManager($serviceManager);
+
+				$sendResponseListener = $serviceManager->get('SendResponseListener');
+				$eventManager = $sendResponseListener->getEventManager();
+				$this->assertEvents($eventManager);
+		}
+
+		protected function assertEvents($eventManager)
+		{
+				$r = new ReflectionProperty($eventManager, 'events');
+				$r->setAccessible(true);
+				$events = $r->getValue($eventManager);
+
+				$this->assertEquals(4, count($events['sendResponse']));
+				$this->assertEquals(ConsoleResponseSender::class, get_class($events['sendResponse']['-2000.0'][0]));
+		}
+}

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -14,6 +14,8 @@ use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Mvc\Console\ResponseSender\ConsoleResponseSender;
 use Zend\Mvc\Console\Service\ConsoleResponseSenderDelegatorFactory;
 
+use ReflectionProperty;
+
 class ServiceManagerTest extends TestCase
 {
     public function testEventManagerOverridden()

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace ZendTest\Mvc\Console;
 
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -26,8 +27,7 @@ class ServiceManagerTest extends TestCase
             ],
             'delegators' => [
                 SendResponseListener::class => [
-                    function(ContainerInterface $container, $name, callable $callback, array $options = null)
-                    {
+                    function (ContainerInterface $container, $name, callable $callback, array $options = null) {
                         $consoleResponseSenderDelegatorFactory = new ConsoleResponseSenderDelegatorFactory();
                         $sendResponseListener = $consoleResponseSenderDelegatorFactory->__invoke($container, $name, $callback, $options);
                         $this->assertInstanceOf(SendResponseListener::class, $sendResponseListener);

--- a/test/ServiceManagerTest.php
+++ b/test/ServiceManagerTest.php
@@ -15,48 +15,49 @@ use Zend\Mvc\Console\Service\ConsoleResponseSenderDelegatorFactory;
 
 class ServiceManagerTest extends TestCase
 {
-		public function testEventManagerOverridden()
-		{
-				$minimalConfig = [
-						'aliases' => [
-								'SendResponseListener' => SendResponseListener::class,
-						],
-						'factories' => [
-								SendResponseListener::class => InvokableFactory::class
-						],
-						'delegators' => [
-								SendResponseListener::class => [
-										function(ContainerInterface $container, $name, callable $callback, array $options = null) {
-												$consoleResponseSenderDelegatorFactory = new ConsoleResponseSenderDelegatorFactory();
-												$sendResponseListener = $consoleResponseSenderDelegatorFactory->__invoke($container, $name, $callback, $options);
-												$this->assertInstanceOf(SendResponseListener::class, $sendResponseListener);
+    public function testEventManagerOverridden()
+    {
+        $minimalConfig = [
+            'aliases' => [
+                'SendResponseListener' => SendResponseListener::class,
+            ],
+            'factories' => [
+                SendResponseListener::class => InvokableFactory::class
+            ],
+            'delegators' => [
+                SendResponseListener::class => [
+                    function(ContainerInterface $container, $name, callable $callback, array $options = null)
+                    {
+                        $consoleResponseSenderDelegatorFactory = new ConsoleResponseSenderDelegatorFactory();
+                        $sendResponseListener = $consoleResponseSenderDelegatorFactory->__invoke($container, $name, $callback, $options);
+                        $this->assertInstanceOf(SendResponseListener::class, $sendResponseListener);
 
-												$eventManager = $sendResponseListener->getEventManager();
-												$this->assertEvents($eventManager);
+                        $eventManager = $sendResponseListener->getEventManager();
+                        $this->assertEvents($eventManager);
 
-												return $sendResponseListener;
-										}
-								],
-						]
-				];
+                        return $sendResponseListener;
+                    }
+                ],
+            ]
+        ];
 
-				$smConfig = new ServiceManagerConfig($minimalConfig);
+        $smConfig = new ServiceManagerConfig($minimalConfig);
 
-				$serviceManager = new ServiceManager();
-				$smConfig->configureServiceManager($serviceManager);
+        $serviceManager = new ServiceManager();
+        $smConfig->configureServiceManager($serviceManager);
 
-				$sendResponseListener = $serviceManager->get('SendResponseListener');
-				$eventManager = $sendResponseListener->getEventManager();
-				$this->assertEvents($eventManager);
-		}
+        $sendResponseListener = $serviceManager->get('SendResponseListener');
+        $eventManager = $sendResponseListener->getEventManager();
+        $this->assertEvents($eventManager);
+    }
 
-		protected function assertEvents($eventManager)
-		{
-				$r = new ReflectionProperty($eventManager, 'events');
-				$r->setAccessible(true);
-				$events = $r->getValue($eventManager);
+    protected function assertEvents($eventManager)
+    {
+        $r = new ReflectionProperty($eventManager, 'events');
+        $r->setAccessible(true);
+        $events = $r->getValue($eventManager);
 
-				$this->assertEquals(4, count($events['sendResponse']));
-				$this->assertEquals(ConsoleResponseSender::class, get_class($events['sendResponse']['-2000.0'][0]));
-		}
+        $this->assertEquals(4, count($events['sendResponse']));
+        $this->assertEquals(ConsoleResponseSender::class, get_class($events['sendResponse']['-2000.0'][0]));
+    }
 }


### PR DESCRIPTION
Should be also related to issue #10.

Because of the `EventManagerAwareInitializer` that is set in `ServiceManagerConfig` the already configured `EventManager` in `SendResponseListener` gets overridden and the `ConsoleResponseSender` is missing. Therefore any console related response can not be rendered.
