### PR TITLE
Promote `ViewManager::getView()` to public visibility

### DIFF
--- a/src/View/ViewManager.php
+++ b/src/View/ViewManager.php
@@ -102,7 +102,7 @@ class ViewManager implements ListenerAggregateInterface
      *
      * @return View
      */
-    private function getView()
+    public function getView()
     {
         if ($this->view) {
             return $this->view;

--- a/test/View/ViewManagerTest.php
+++ b/test/View/ViewManagerTest.php
@@ -447,4 +447,18 @@ class ViewManagerTest extends TestCase
         $manager = new ViewManager();
         $this->assertNull($manager->onBootstrap($event->reveal()));
     }
+
+    /**
+     * @group 14
+     */
+    public function testViewAccessorIsPublic()
+    {
+        $view = $this->prophesize(View::class)->reveal();
+        $viewmanager = new ViewManager();
+        $r = new ReflectionProperty($viewmanager, 'view');
+        $r->setAccessible(true);
+        $r->setValue($viewmanager, $view);
+
+        $this->assertSame($view, $viewmanager->getView());
+    }
 }


### PR DESCRIPTION
Modules such as zf-rpc were calling the method, regardless of what type `ViewManager` is, making it de facto part of the public interface. This patch promotes the visibility so that it can be called this way.

Fixes #14
