### PR TITLE
Fix check if `instanceof RouteMatch` (detected via static analysis)

### DIFF
--- a/src/Service/ConsoleViewHelperManagerDelegatorFactory.php
+++ b/src/Service/ConsoleViewHelperManagerDelegatorFactory.php
@@ -9,6 +9,7 @@ namespace Zend\Mvc\Console\Service;
 
 use Interop\Container\ContainerInterface;
 use Zend\Console\Console;
+use Zend\Router\RouteMatch;
 use Zend\ServiceManager\DelegatorFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Helper as ViewHelper;


### PR DESCRIPTION
This check was always false.
The old check was searching for `\Zend\Mvc\Console\Service\RouteMatch`,
which doesn't exist.

setRouteMatch accepts `\Zend\Router\RouteMatch` or the legacy subclass:

The possibilities (From the Zend\View\Helper\Url code):

    // MVC router extends RouteMatch.
    use Zend\Mvc\Router\RouteMatch as LegacyRouteMatch;
    use Zend\Router\RouteMatch;

Note: There were no unit tests of this case. Existing unit tests pass.