### PR TITLE
call $e->getRequest() only when it is used at RouteNotFoundStrategy::handleRouteNotFoundError() by move it to the line that actually will use it in next flow

### DIFF
--- a/src/View/RouteNotFoundStrategy.php
+++ b/src/View/RouteNotFoundStrategy.php
@@ -90,7 +90,6 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
         }
 
         $response = $e->getResponse();
-        $request  = $e->getRequest();
 
         switch ($error) {
             case Application::ERROR_CONTROLLER_NOT_FOUND:
@@ -139,6 +138,7 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
             throw new RuntimeException('Cannot access Console adapter - is it defined in ServiceManager?');
         }
 
+        $request = $e->getRequest();
         // Retrieve the script's name (entry point)
         $scriptName = '';
         if ($request instanceof ConsoleRequest) {


### PR DESCRIPTION
- [x] Is this related to quality assurance?
